### PR TITLE
Navegación entre interfaces

### DIFF
--- a/src/components/admin/AdminNavbar.jsx
+++ b/src/components/admin/AdminNavbar.jsx
@@ -11,9 +11,23 @@ import imagenLogo from '../../assets/isotipo.png'
 import imagenLogoAlt from '../../assets/isotipoAlt.png'
 import Button from '@mui/material/Button'
 import CloseIcon from '@mui/icons-material/Close'
-import { administrador } from '../../components/admin/navigationData'
+import { administrador, vendedor } from '../../components/admin/navigationData'
 
-const TestNavbar = () => {
+// Carga la colección de datos correspondiente al rol
+let usuarioAdmin = administrador
+let usuarioVende = vendedor
+
+const TestNavbar = (props) => {
+  // Variable vacia que recibe el rol actual
+  let usuarioActual = undefined
+
+  // Selecciona el tipo de datos correspondiente al rol enviado desde el padre
+  if (props.usuario === 'admin') {
+    usuarioActual = usuarioAdmin
+  } else {
+    usuarioActual = usuarioVende
+  }
+
   // reactHook para el contenedor Collapse del menú hamburguesa
   const [expanded, setExpanded] = React.useState(false)
 
@@ -51,7 +65,7 @@ const TestNavbar = () => {
               />
             </IconButton>
             <Box sx={{ ...barraPC }}>
-              {administrador.map((datos, index) => {
+              {usuarioActual.map((datos, index) => {
                 const { pagina, url, estado } = datos
                 return (
                   <Button
@@ -73,7 +87,7 @@ const TestNavbar = () => {
               unmountOnExit
               sx={{ ...barraMovil }}
             >
-              {administrador.map((datos, index) => {
+              {usuarioActual.map((datos, index) => {
                 const { pagina, url, estado } = datos
                 return (
                   <Typography

--- a/src/pages/admin/ordersclient.jsx
+++ b/src/pages/admin/ordersclient.jsx
@@ -1,9 +1,37 @@
+import * as React from 'react'
+import AdminNavbar from '../../components/admin/AdminNavbar'
+import { vendedor } from '../../components/admin/navigationData'
+
 function OrdersClient() {
+  // ReactHook para cambiar el estado de la pagina actual
+  const [paginaActual, setPaginaActual] = React.useState(false)
+
+  const ponerEstadoPagina = () => {
+    setPaginaActual((vendedor[1].estado = !paginaActual))
+  }
+
+  // ReactHook para cambiar el estado de todas las paginas y de la pagina actual
+  React.useEffect(() => {
+    limpiarPagina()
+    ponerEstadoPagina()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <div>
+      <AdminNavbar />
       <h1>Tu listado de pedidos</h1>
     </div>
-  );
+  )
 }
 
-export default OrdersClient;
+export default OrdersClient
+
+// Logica del padre para la barra de navegación
+
+// Función que devuelve el estado de todas las paginas a falso
+const limpiarPagina = () => {
+  for (let i = 0; i < vendedor.length; i++) {
+    vendedor[i].estado = false
+  }
+}

--- a/src/pages/admin/productmanag.jsx
+++ b/src/pages/admin/productmanag.jsx
@@ -41,7 +41,7 @@ function ProductManagement({ title }) {
 
   return (
     <div>
-      <AdminNavbar estado='1' />
+      <AdminNavbar usuario='admin' />
       <Box
         sx={{
           pr: '48px',

--- a/src/pages/admin/registry.jsx
+++ b/src/pages/admin/registry.jsx
@@ -1,9 +1,37 @@
+import * as React from 'react'
+import AdminNavbar from '../../components/admin/AdminNavbar'
+import { vendedor } from '../../components/admin/navigationData'
+
 function Registry() {
+  // ReactHook para cambiar el estado de la pagina actual
+  const [paginaActual, setPaginaActual] = React.useState(false)
+
+  const ponerEstadoPagina = () => {
+    setPaginaActual((vendedor[2].estado = !paginaActual))
+  }
+
+  // ReactHook para cambiar el estado de todas las paginas y de la pagina actual
+  React.useEffect(() => {
+    limpiarPagina()
+    ponerEstadoPagina()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <div>
+      <AdminNavbar />
       <h1>Aquí está tu archivo</h1>
     </div>
-  );
+  )
 }
 
-export default Registry;
+export default Registry
+
+// Logica del padre para la barra de navegación
+
+// Función que devuelve el estado de todas las paginas a falso
+const limpiarPagina = () => {
+  for (let i = 0; i < vendedor.length; i++) {
+    vendedor[i].estado = false
+  }
+}

--- a/src/pages/admin/report.jsx
+++ b/src/pages/admin/report.jsx
@@ -1,9 +1,37 @@
+import * as React from 'react'
+import AdminNavbar from '../../components/admin/AdminNavbar'
+import { vendedor } from '../../components/admin/navigationData'
+
 function Report() {
+  // ReactHook para cambiar el estado de la pagina actual
+  const [paginaActual, setPaginaActual] = React.useState(false)
+
+  const ponerEstadoPagina = () => {
+    setPaginaActual((vendedor[0].estado = !paginaActual))
+  }
+
+  // ReactHook para cambiar el estado de todas las paginas y de la pagina actual
+  React.useEffect(() => {
+    limpiarPagina()
+    ponerEstadoPagina()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <div>
+      <AdminNavbar />
       <h1>Hola vendedor aquí encuentras el informe de tus ventas</h1>
     </div>
-  );
+  )
 }
 
-export default Report;
+export default Report
+
+// Logica del padre para la barra de navegación
+
+// Función que devuelve el estado de todas las paginas a falso
+const limpiarPagina = () => {
+  for (let i = 0; i < vendedor.length; i++) {
+    vendedor[i].estado = false
+  }
+}

--- a/src/pages/admin/salesrep.jsx
+++ b/src/pages/admin/salesrep.jsx
@@ -19,7 +19,7 @@ function SalesReport() {
 
   return (
     <div>
-      <AdminNavbar estado='3' />
+      <AdminNavbar usuario='admin' />
       <h1>Aquí generas los reportes de venta</h1>
     </div>
   )

--- a/src/pages/admin/sellermanag.jsx
+++ b/src/pages/admin/sellermanag.jsx
@@ -41,7 +41,7 @@ function SellerManagement({ title }) {
 
   return (
     <div>
-      <AdminNavbar estado='2' />
+      <AdminNavbar usuario='admin' />
       <Box
         sx={{
           pr: '48px',


### PR DESCRIPTION
Se agregó la navegación entre todas las interfaces principales del portal administrativo, tanto para administradores como para vendedores.

![image](https://user-images.githubusercontent.com/83623263/142777472-c0488d64-5f83-46aa-83ef-ac9a70286bd4.png)


**Agregado**:
- Navegación entre todas las rutas del portal administrativo, con la lógica del componente.
- `AdminNavBar` ahora recibe un prop `usuario='admin'`, con este prop `AdminNavBar` compara con un string la palabra ingresada, si es 'admin', la barra de navegación imprimirá todos los botones para el administrador, de lo contrario, imprimirá todos los botones para el vendedor.
- Endpoint temporal `/test` de pruebas que tiene todas las rutas del portal administrativo.